### PR TITLE
feat: add plain cfp page

### DIFF
--- a/main.py
+++ b/main.py
@@ -68,6 +68,15 @@ def home():
     return render_template("index.html", **data)
 
 
+@app.route("/calls.html")
+def calls():
+    data = _data()
+    data["calls"] = site_data["calls"]["calls"]
+    for call in data["calls"]:
+        call["bodytext"] = open(call["body"]).read()
+    return render_template("calls.html", **data)
+
+
 # ITEM PAGES
 @app.route("/static/<path:path>")
 def send_static(path):

--- a/sitedata/calls.yml
+++ b/sitedata/calls.yml
@@ -1,0 +1,5 @@
+calls:
+  - id: 1
+    title: INLG 2023 Call for Papers
+    deadline: May 22, 2023 11:59:59 PM AOE
+    body: sitedata/cfp.md

--- a/sitedata/cfp.md
+++ b/sitedata/cfp.md
@@ -1,0 +1,85 @@
+### Call For papers: 16th International  Natural Language Generation Conference (INLG 2023)
+
+We invite the submission of long and short papers, as well as system demonstrations, related to all aspects of Natural Language Generation (NLG), including data-to-text, concept-to-text, text-to-text and vision-to-text approaches. Accepted papers will be presented as oral talks or posters.
+
+The event is organized under the auspices of the Special Interest Group on Natural Language Generation ([SIGGEN](https://aclweb.org/aclwiki/SIGGEN)) of the Association for Computational Linguistics ([ACL](https://aclweb.org/)). The event will be held from 11-15 September in Prague, Czech Republic. INLG 2023 will be (jointly) colocated with [SIGDial 2023](https://2023.sigdial.org/).
+
+### Important dates
+
+All deadlines are Anywhere on Earth (UTC-12)
+
+* ***UPDATE: START system regular paper title & abstract submission deadline: May 22, 2023***
+* ***UPDATE: START system full paper submission deadline: May 29, 2023***
+* ***UPDATE: ARR commitment to INLG deadline via START system: June 19, 2023***
+* START system demo paper submission deadline: June 15, 2023
+* Notification: July 11, 2023
+* Camera ready: July 25, 2023
+* Conference: 11-15 September 2023
+
+### Submission website
+
+You can make your submissions to INLG 2023 [here](https://softconf.com/n/inlg2023/).
+
+### Topics
+
+INLG 2023 solicits papers on any topic related to NLG. General topics of interest include, but are not limited to:
+
+* Affect/emotion generation
+* Analysis and detection of automatically generated text
+* Bias and fairness in NLG systems
+* Cognitive modelling of language production
+* Computational efficiency of NLG models
+* Content and text planning
+* Corpora and resources for NLG
+* Ethical considerations of NLG
+* Evaluation and error analysis of NLG systems
+* Explainability and Trustworthiness of NLG systems
+* Generalizability of NLG systems
+* Grounded language generation
+* Large Language Models for NLG
+* Lexicalisation
+* Multimedia and multimodality in generation
+* Natural language understanding techniques for NLG
+* NLG and accessibility
+* NLG in speech synthesis and spoken language models
+* NLG in dialogue
+* NLG for human-robot interaction
+* NLG for low-resourced languages
+* NLG for real-world applications
+* Paraphrasing, summarization and translation
+* Personalisation and variation in text
+* Referring expression generation
+* Storytelling and narrative generation
+* Surface realisation
+* System architectures
+
+### Submissions & Format
+
+Three kinds of papers can be submitted:
+
+* <span style="text-decoration:underline;">Long papers</span> are most appropriate for presenting substantial research results and must not exceed eight (8) pages of content, plus unlimited pages of ethical considerations, supplementary material statements, and references. The supplementary material statement provides detailed descriptions to support the reproduction of the results presented in the paper (see below for details). The final versions of long papers will be given one additional page of content (up to 9 pages) so that reviewers' comments can be taken into account.
+* <span style="text-decoration:underline;">Short papers</span> are more appropriate for presenting an ongoing research effort and must not exceed four (4) pages, plus unlimited pages of ethical considerations, supplementary material statements, and references. The final versions of short papers will be given one additional page of content (up to 5 pages) so that reviewers' comments can be taken into account.
+* <span style="text-decoration:underline;">Demo papers</span> should be no more than two (2) pages, including references, and should describe implemented systems relevant to the NLG community. It also should include a link to a short screencast of the working software. In addition, authors of demo papers must be willing to present a demo of their system during INLG 2023.
+
+Submissions should follow [ACL Author Guidelines](https://www.aclweb.org/adminwiki/index.php?title=ACL_Author_Guidelines) and policies for submission, review and citation, and be anonymised for double blind reviewing. Please use ACL 2023 style files; LaTeX style files and Microsoft Word templates are available at[ https://2023.aclweb.org/calls/style_and_formatting/](https://2023.aclweb.org/calls/style_and_formatting/).
+
+Authors must honour the ethical code set out in the [ACL Code of Ethics](https://www.aclweb.org/portal/content/acl-code-ethics). If your work raises any ethical issues, you should include an explicit discussion of those issues. This will also be taken into account in the review process. You may find [this checklist](https://aclrollingreview.org/responsibleNLPresearch/) of use.
+
+Authors are strongly encouraged to ensure that their work is reproducible; see, e.g., the following [reproducibility checklist](https://2021.aclweb.org/calls/reproducibility-checklist/). Papers involving any kind of experimental results (human judgments, system outputs, etc) should incorporate a data availability statement into their paper. Authors are asked to indicate whether the data is made publicly available. If the data is not made available, authors should provide a brief explanation why. (E.g. because the data contains proprietary information.) A [statement guide](https://inlg2023.github.io/resource_statement.html) is available on the INLG 2023 website.
+
+To submit a long or short paper to INLG 2023, authors can either submit directly or commit a paper previously reviewed by ARR via the same [paper submission site](https://softconf.com/n/inlg2023/). For direct submissions, the deadline for submitting abstracts and titles of papers is May 22, 2023, 11:59:59 PM AOE and the full paper submission deadline is May 29, 2023, 11:59:59 PM AOE. If committing an ARR paper to INLG, the submission is also made through the INLG 2023 paper submission site, indicating the link of the paper on OpenReview. The deadline for committing an ARR paper to INLG is June 19, 2023, 11:59:59 PM AOE, and the last eligible ARR paper submission deadline for INLG 2023 is April 15, 2023. It is important to note that when committing an ARR paper to INLG, it should be submitted through the INLG 2023 paper submission site, just like a direct submission paper, with the only difference being the need to provide the OpenReview link to the paper and to provide an optional author response to reviews.
+
+Demo papers should be submitted directly through the INLG 2023 [paper submission site](https://softconf.com/n/inlg2023/) by June 15, 2023, 11:59:59 PM AOE.
+
+All accepted papers will be published in the INLG 2023 proceedings and included in the ACL anthology. A paper accepted for presentation at INLG 2023 must not have been presented at any other meeting with publicly available proceedings. Dual submission to other conferences is permitted, provided that authors clearly indicate this in the submission form. If the paper is accepted at both venues, the authors will need to choose which venue to present at, since they can not present the same paper twice.
+
+### Awards
+
+INLG 2023 will present several awards to recognize outstanding achievements in the field. These awards are:
+
+* Best Long Paper Award: This award will be given to the best long paper submission based on its originality, impact, and contribution to the field of NLG.
+* Best Short Paper Award: This award will be given to the best short paper submission based on its originality, impact, and contribution to the field of NLG.
+* Best Demo Paper Award: This award will recognize the best demo paper submitted to the conference. This award considers not only the paper's quality but also the demonstration given at the conference. The demonstration will play a significant role in the judging process.
+* Best Evaluation Award: The award is a new addition to INLG 2023. This award is designed to honour authors who have demonstrated the most comprehensive and insightful analysis in evaluating their results. This award aims to highlight papers where the authors have gone the extra mile in providing a thorough and detailed analysis of their results, offering a nuanced understanding of their findings.
+
+Frequently asked questions about committing a paper from ACL Rolling Review are answered in the [Help](https://inlg2023.github.io/help.html) tab.

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -18,6 +18,7 @@ body {
 
 .jumbotron {
   background-color: rgba(236, 241, 246, 1);
+  margin: 0;
 }
 
 .btn-group {
@@ -85,13 +86,24 @@ body .nav-pills .nav-link.active {
   box-sizing: border-box;
 }
 
-.cards {
-  margin-top: 10px;
-}
-
 .card-title {
   margin-top: 10px;
   font-size: 20px;
+}
+
+.card {
+  border-radius: 0.8rem;
+  border: 0px;
+  background: #fff;
+  padding: 1rem 1.5rem 1rem 1.5rem;
+  box-shadow: rgb(204, 204, 204) 2px 2px 14px 0;
+  border-radius: 0.8rem;
+}
+
+.card-header {
+  padding: 0;
+  background-color: rgb(0, 0, 0, 0);
+  border-bottom: 0;
 }
 
 h2.card-title {

--- a/templates/base.html
+++ b/templates/base.html
@@ -27,7 +27,7 @@
     <script src="https://cdn.jsdelivr.net/npm/moment-timezone@0.5.28/builds/moment-timezone-with-data.min.js"
         integrity="sha256-IWYg4uIC8/erItNXYvLtyYHioRi2zT1TFva8qaAU/ww=" crossorigin="anonymous"></script>
 
-    <link href="https://cdn.jsdelivr.net/gh/coliff/bootstrap-rfs/bootstrap-rfs.css" rel="stylesheet">
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
 
 
     <!-- Library libs_ext -->
@@ -90,12 +90,11 @@
                     <li class="nav-item active">
                         <a class="nav-link" href="index.html">Home</a>
                     </li>
-
-                    <!--
                     <li class="nav-item ">
                         <a class="nav-link" href="calls.html">Calls</a>
                     </li>
 
+                    <!--
                     <li class="nav-item ">
                         <a class="nav-link" href="workshops.html">Workshops</a>
                     </li>
@@ -151,13 +150,51 @@
 
     {% block body %}
     <!-- User Overrides -->
-    {% block top %} {% endblock %}
+    <style>
+    .back {
+        position: relative;
+        background: url("{{config.background_image}}") no-repeat center;
+        background-size: cover;
+    }
+    
+    .back h2 {
+        font-weight: 600;
+    }
+    
+    .back h3 {
+        font-weight: 300;
+    }
+
+    .back .dark-filter {
+        top: 0;
+        position: absolute;
+        height: 100%;
+        width: 100%;
+        opacity: 60%;
+        background-color: black;
+    }
+
+    .content {
+        margin-top: 2rem;
+        margin-bottom: 2rem;
+    }
+    </style>
+    
+    <div class="jumbotron jumbotron-fluid back">
+        <div class="dark-filter"></div>
+        <div class="row header m-5">
+            <div class="p-1 mx-auto text-center text-white col-md-9 col-sm-12">
+            <h2 class="display-4">
+                {{ config.tagline | safe }}
+            </h2>
+            <h3 class="mt-4">
+                {{ config.date | safe }} @ {{ config.place | safe }}
+            </h3>
+            </div>
+        </div>
+    </div>
 
     <div class="container">
-        <!-- Tabs -->
-        <div class="tabs">
-            {% block tabs %} {% endblock %}
-        </div>
         <!-- Content -->
         <div class="content">
             {% block content %} {% endblock %}

--- a/templates/calls.html
+++ b/templates/calls.html
@@ -1,0 +1,10 @@
+{% set active_page = "Calls" %}
+{% extends "base.html" %}
+
+{% block content %}
+
+{{ components.section("Calls") }}
+<!-- {{ components.callgroup(calls) }} -->
+<h5 class="text-center">To be announced</h5>
+
+{% endblock %}

--- a/templates/components.html
+++ b/templates/components.html
@@ -87,9 +87,8 @@ sessiongroup
 {%- endmacro %}
 
 {% macro section(name) -%}
-<div class="border-top my-3"></div>
-<div class="row p-4" id="faq">
-    <div class="col-12 bd-content">
+<div class="row mb-4">
+    <div class="col-12">
         <h2 class="text-center">{{name}}</h2>
     </div>
 </div>
@@ -97,7 +96,7 @@ sessiongroup
 
 {% macro subsection(name) -%}
 <div class="row p-3">
-    <div class="col-12 bd-content">
+    <div class="col-12">
         <h3>{{name}}</h3>
     </div>
 </div>
@@ -249,16 +248,16 @@ sessiongroup
 {% set rowloop = loop.index %}
 <div class="row">
     <div class="col-12" id="accordionExample">
-        <div class="card m-2">
-            <div class="card-header">
-                <a class="" href="#" data-toggle="collapse" data-target="#collapse{{rowloop}}-{{loop.index}}"
+        <div class="card">
+            <div class="card-header" id="heading{{rowloop}}-{{loop.index}}">
+                <a class="" href="#" data-toggle="collapse" data-target="#collapse{{rowloop}}-{{loop.index}}" role="button"
                     aria-expanded="true" aria-controls="collapse{{rowloop}}-{{loop.index}}">
-                    {{call.title}}
-                </a>, deadline {{call.deadline}}
+                    {{ call.title }}
+                </a>, deadline {{ call.deadline }}
             </div>
-            <div id="collapse{{rowloop}}-{{loop.index}}" class="collapse" aria-labelledby="headingOne"
+            <div id="collapse{{rowloop}}-{{loop.index}}" class="collapse mt-3" aria-labelledby="heading{{rowloop}}-{{loop.index}}"
                 data-parent="#accordionExample">
-                <div class="card-body">
+                <div class="card-body markdown">
                     {{ call.bodytext | markdown }}
                 </div>
             </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,46 +1,6 @@
 {% set active_page = "Home" %}
 {% extends "base.html" %}
 
-{% block top %}
-<style>
-  .back {
-    position: relative;
-    background: url("{{config.background_image}}") no-repeat center;
-    background-size: cover;
-  }
-
-  .back h2 {
-    font-weight: 600;
-  }
-
-  .back h3 {
-    font-weight: 300;
-  }
-  .back .dark-filter {
-    top: 0;
-    position: absolute;
-    height: 100%;
-    width: 100%;
-    opacity: 60%;
-    background-color: black;
-  }
-</style>
-
-<div class="jumbotron jumbotron-fluid back">
-  <div class="dark-filter"></div>
-  <div class="row header m-5">
-    <div class="p-1 mx-auto text-center text-white col-md-9 col-sm-12">
-      <h2 class="display-4">
-        {{ config.tagline | safe }}
-      </h2>
-      <h3 class="mt-4">
-        {{ config.date | safe }} @ {{ config.place | safe }}
-      </h3>
-    </div>
-  </div>
-</div>
-{% endblock %}
-
 {% block content %}
 
 <div class="container-fluid">
@@ -53,4 +13,5 @@
     <!--    </div>-->
   </div>
 </div>
+
 {% endblock %}


### PR DESCRIPTION
It will be shown like this:
![127 0 0 1_5000_calls html](https://github.com/inlg2024/inlg2024.github.io/assets/13232817/8ae01fe4-e762-4e3e-b141-83c4ca72edc4)

Right now, only "TBA" is shown:
![スクリーンショット 2024-03-26 1 05 57](https://github.com/inlg2024/inlg2024.github.io/assets/13232817/4d292e46-0189-43a3-ae97-3c20926de91d)