### PR TITLE
fix: delete ARR from the FAQ page

### DIFF
--- a/sitedata/faq.yml
+++ b/sitedata/faq.yml
@@ -1,5 +1,5 @@
 faq:
-  - section: Frequently Asked Questions about ARR
+  - section: Frequently Asked Questions
     qa:
       - question: Can you issue an invitation letter for visa application?
         answer: Yes, please contact the local chair, Tatsuya Ishigaki (ishigaki.tatsuya [at] aist.go.jp)


### PR DESCRIPTION
FAQページから「about ARR」という記述を削除